### PR TITLE
feat(mipush): handle missing key by environment mode & update README run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a notification microservice.
 
 ## Features
-- support apns and mipush notifications 
+- support apns and mipush notifications
 - REST API to manage notification and user device tokens
 
 ## Usage
@@ -20,12 +20,22 @@ go build -o notification.exe
 ./notification.exe
 ```
 
+### Run
+Before running, export `MODE` and `BASE_PATH`:
+
+```bash
+export BASE_PATH=$PWD
+# Available modes: production / dev / test / perf
+export MODE=dev
+go run main.go
+```
+
 ### Test
 Please export `MODE=test` and `BASE_PATH=$PWD`
 to avoid relative path errors in unit tests.
 
-Device tokens must be set to test push notifications, 
-export `${service}_DEVICE_TOKEN` for each push service, 
+Device tokens must be set to test push notifications,
+export `${service}_DEVICE_TOKEN` for each push service,
 e.g. `APNS_DEVICE_TOKEN=1234567`
 
 ### API Docs
@@ -51,7 +61,7 @@ Please visit http://localhost:8000/docs after running app
 
 Feel free to dive in! [Open an issue](https://github.com/OpenTreeHole/notification/issues/new) or [Submit PRs](https://github.com/OpenTreeHole/notification/compare).
 
-We are now in rapid development, any contribution would be of great help. 
+We are now in rapid development, any contribution would be of great help.
 For the developing roadmap, please visit [this issue](https://github.com/OpenTreeHole/notification/issues/1).
 
 ### Contributors

--- a/push/mipush/init.go
+++ b/push/mipush/init.go
@@ -17,15 +17,53 @@ var client = http.Client{Timeout: timeout}
 var authorization string
 
 func init() {
+
 	log.Debug().Msg("init mipush")
-	authorization = "key=" + getMipushKey()
+	key, _ := getMipushKey()
+	authorization = "key=" + key
 }
 
-func getMipushKey() string {
+func getMipushKey() (string, error) {
 	data, err := os.ReadFile(config.Config.MipushKeyPath)
+
 	if err != nil {
 		pwd, _ := os.Getwd()
-		log.Fatal().Str("pwd", pwd).Err(err).Str("scope", "init mipush").Msg("failed to read mipush key")
+
+		switch config.Config.Mode {
+		case "production":
+			// 在生产环境中严格要求 key 存在
+			log.Fatal().
+				Str("pwd", pwd).
+				Err(err).
+				Str("scope", "init mipush").
+				Msg("failed to read mipush key in production")
+			// 不会执行到这里
+			return "", err
+
+		case "dev", "test":
+			// 在开发或测试环境中只警告，不终止
+			log.Warn().
+				Str("pwd", pwd).
+				Err(err).
+				Str("scope", "init mipush").
+				Msg("failed to read mipush key, using empty key in non-production mode")
+			return "", nil
+
+		case "perf":
+			// 压测环境用 mock key
+			log.Info().
+				Str("scope", "init mipush").
+				Msg("using mock mipush key for perf mode")
+			return "mock-mipush-key", nil
+
+		default:
+			// 未知模式时明确报错退出
+			log.Fatal().
+				Str("scope", "init mipush").
+				Str("mode", config.Config.Mode).
+				Msg("unknown mode while reading mipush key")
+			return "", err
+		}
 	}
-	return string(data)
+	return string(data), nil
 }


### PR DESCRIPTION
### 🧩 Summary
This PR introduces environment-aware behavior for the Mipush key initialization
and updates the documentation to reflect the new MODE settings.

- Code changes
  - mipush/init.go
  - Refactored getMipushKey() to handle missing keys differently across modes:
    - production → fatal if key missing
    - dev / test → warn and continue
    - perf → use mock key
    - default → fatal for unknown mode
  - Prevents non-production environments from aborting on missing keys.
	

- Documentation changes
  - README.md
  - Added a Run section showing how to export MODE and BASE_PATH.
  - Clarified available modes: production, dev, test, perf.
  - Minor formatting cleanup.


### 🎯 Motivation

Previously, missing push-key files caused startup failure even in development or testing environments.
This PR makes startup behavior mode-aware and updates the README to help contributors understand and use these modes correctly.